### PR TITLE
fixed locked retrieve strategy 'waitForResult'

### DIFF
--- a/src/managers/BaseManager.ts
+++ b/src/managers/BaseManager.ts
@@ -64,7 +64,7 @@ export abstract class BaseManager {
     try {
       isKeySuccessfullyLocked = await this.storage.lockKey(context.key);
     } catch (keyLockError: unknown) {
-      this.logger.error(
+      this.logger.info(
         `Error occurred while trying to lock key "${context.key}". Reason: ${
           (keyLockError as Error).message
         }. Running executor`
@@ -75,7 +75,7 @@ export abstract class BaseManager {
     }
 
     try {
-      this.logger.trace(`Running executor for key "${context.key}"`);
+      this.logger.info(`Running executor for key "${context.key}"`);
       const executorResult = await runExecutor(context.executor);
 
       await this.set(context.key, executorResult, options);

--- a/src/managers/BaseManager.ts
+++ b/src/managers/BaseManager.ts
@@ -23,8 +23,8 @@ export abstract class BaseManager {
       [
         LockedKeyRetrieveStrategyTypes.waitForResult,
         new WaitForResultLockedKeyRetrieveStrategy({
-          keyLockCheckFn: this.storage.keyIsLocked.bind(this),
-          getRecord: this.storage.get.bind(this),
+          keyLockCheckFn: this.storage.keyIsLocked.bind(this.storage),
+          getRecord: this.storage.get.bind(this.storage),
           logger: this.logger,
         }),
       ],
@@ -69,10 +69,7 @@ export abstract class BaseManager {
           (keyLockError as Error).message
         }. Running executor`
       );
-
-      return runExecutor(context.executor);
     }
-
     if (!isKeySuccessfullyLocked) {
       return lockedKeyRetrieveStrategy.get(context);
     }


### PR DESCRIPTION
### Bug report
Unexpected behaviour when using 'waitForResult' strategy 

### Expected
Key is locked before running executor.

### Actual
Exceptions `TypeError: Cannot read property 'isLockExists' of undefined` are thrown.

### Step to reproduce
Are implemented in `tests/integration/cache.spec.ts` as `Concurrent test`.